### PR TITLE
Update ViewTicket.php

### DIFF
--- a/app/Filament/Resources/TicketResource/Pages/ViewTicket.php
+++ b/app/Filament/Resources/TicketResource/Pages/ViewTicket.php
@@ -238,4 +238,14 @@ class ViewTicket extends ViewRecord implements HasForms
         $this->form->fill();
         $this->selectedCommentId = null;
     }
+
+    /**
+     * Overrides the getFormStatePath method to set its access level to public.
+     *
+     * @return string
+     */
+    public function getFormStatePath(): string
+    {
+        return 'form';
+    }
 }


### PR DESCRIPTION
Override the getFormStatePath() to set it to public to resolve the access level error reported in InteractsWithForms::getFormStatePath() from Filament.

I admittedly haven't reviewed the rest of this project, but I saw the error you were encountering on the Filament open issues. I had this happen on something of my own and this is how I resolved it.